### PR TITLE
Challenge 1 - wrong state

### DIFF
--- a/features/list/src/main/java/com/vp/list/ListFragment.java
+++ b/features/list/src/main/java/com/vp/list/ListFragment.java
@@ -69,7 +69,7 @@ public class ListFragment extends Fragment implements GridPagingScrollListener.L
 
         initBottomNavigation(view);
         initList();
-        listViewModel.observeMovies().observe(this, searchResult -> {
+        listViewModel.observeMovies().observe(getViewLifecycleOwner(), searchResult -> {
             if (searchResult != null) {
                 handleResult(listAdapter, searchResult);
             }

--- a/features/list/src/main/java/com/vp/list/viewmodel/ListViewModel.java
+++ b/features/list/src/main/java/com/vp/list/viewmodel/ListViewModel.java
@@ -49,7 +49,6 @@ public class ListViewModel extends ViewModel {
 
                 if (result != null) {
                     aggregatedItems.addAll(result.getSearch());
-                    currentTitle = title;
                     liveData.setValue(SearchResult.success(aggregatedItems, result.getTotalResults()));
                 }
             }

--- a/features/list/src/main/java/com/vp/list/viewmodel/ListViewModel.java
+++ b/features/list/src/main/java/com/vp/list/viewmodel/ListViewModel.java
@@ -49,6 +49,8 @@ public class ListViewModel extends ViewModel {
 
                 if (result != null) {
                     aggregatedItems.addAll(result.getSearch());
+                    currentTitle = title;
+                    liveData.setValue(SearchResult.success(aggregatedItems, result.getTotalResults()));
                 }
             }
 

--- a/features/list/src/test/java/com/vp/list/viewmodel/ListViewModelTest.java
+++ b/features/list/src/test/java/com/vp/list/viewmodel/ListViewModelTest.java
@@ -10,6 +10,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import retrofit2.mock.Calls;
 
@@ -52,6 +53,24 @@ public class ListViewModelTest {
 
         //then
         verify(mockObserver).onChanged(SearchResult.inProgress());
+    }
+
+
+    @Test
+    public void shouldReturnSuccessState() {
+        //given
+        SearchResponse searchResponse = mock(SearchResponse.class);
+        when(searchResponse.getSearch()).thenReturn(Collections.emptyList());
+        when(searchResponse.getTotalResults()).thenReturn(0);
+        SearchService searchService = mock(SearchService.class);
+        when(searchService.search(anyString(), anyInt())).thenReturn(Calls.response(searchResponse));
+        ListViewModel listViewModel = new ListViewModel(searchService);
+
+        //when
+        listViewModel.searchMoviesByTitle("title", 1);
+
+        //then
+        assertThat(listViewModel.observeMovies().getValue().getListState()).isEqualTo(ListState.LOADED);
     }
 
 }


### PR DESCRIPTION
**Context:** 
This PR fixes a bug whereby the `List` feature was stuck in an incorrect state. 

**Detail:**
Although we were correctly adding the search results to the viewmodel's `aggregatedItems`, we were NOT updating the observable state being exposed, and therefore the view was never being updated. 

**Key changes:**
- updated MutableLiveData in the `onResponse` as a result of calling the `SearchService`
- added a meaningful unit test to cover this bug from sneaking back into this feature again
- following boyscout rule of leaving the code slightly cleaner than I found it
while reading through the codebase, enforced a best practice of using getViewLifecycleOwner instead of the  `this` instance referencing the Fragment