### PR TITLE
Challenge 2 - Lost event

### DIFF
--- a/features/list/src/main/java/com/vp/list/ListFragment.java
+++ b/features/list/src/main/java/com/vp/list/ListFragment.java
@@ -164,6 +164,25 @@ public class ListFragment extends Fragment implements GridPagingScrollListener.L
 
     @Override
     public void onItemClick(String imdbID) {
-        //TODO handle click events
+        // this module intentionally contains no dependency on the "Detail" feature-module
+        // therefore, we instead rely on the Implicit resolution of any activity that can
+        // handle the intent to VIEW this URI, as is defined in the  Detail feature-module's
+        // AndroidManifest file
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        Uri destinationUri = Uri.parse("app://movies/detail/?imdbID=" + imdbID);
+        intent.setData(destinationUri);
+
+        // Check if there are activities that can handle the intent
+        // in the case that there are no activities that can handle the intent,
+        // this equates to an illegal state and should throw a Runtime Error
+        // in this way we make it more obvious that there is a problem and prevent
+        // shipping with an easily preventable issue
+        if (intent.resolveActivity(requireContext().getPackageManager()) != null) {
+            startActivity(intent);
+        } else {
+            // if this happens, it means that the Detail feature-module's activity (or activity
+            // definition within the AndroidManifest) has changed in someway that breaks compatibility
+            throw new IllegalStateException("No activity exists that can handle the intent to VIEW movie detail");
+        }
     }
 }


### PR DESCRIPTION
**Context:**
This PR addresses the `TODO` to handle the click event when a movie in the list is clicked.

**Detail:**
We need to launch the `DetailActivity`, however... 
- we can't launch the intent _explicitly_ without creating a dependency on the `detail` feature module from the `list` feature module which is undesirable as it's better to ensure that all feature modules remain independent and don't unintentionally start crossing borders, therefore...
- we instead launch the intent _implicitly_ using the VIEW action and an appropriate URI, based on the definition in the Detail module's manifest for that DetailActivity.

**Key changes:**
- launch the DetailActivity for a given selected movie from the list
- throw an appropriate runtime exception if no activity is resolved which would indicate a developer error, this includes some meaningful context/comments to facilitate any future debugging and problem solving. 