### PR TITLE
Challenge 3 - lost state

### DIFF
--- a/features/list/src/main/java/com/vp/list/MovieListActivity.java
+++ b/features/list/src/main/java/com/vp/list/MovieListActivity.java
@@ -17,11 +17,13 @@ import dagger.android.HasAndroidInjector;
 
 public class MovieListActivity extends AppCompatActivity implements HasAndroidInjector {
     private static final String IS_SEARCH_VIEW_ICONIFIED = "is_search_view_iconified";
+    private static final String QUERY_STRING = "query_string";
 
     @Inject
     DispatchingAndroidInjector<Object> dispatchingActivityInjector;
     private SearchView searchView;
     private boolean searchViewExpanded = true;
+    private String searchViewContent = "";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -36,6 +38,7 @@ public class MovieListActivity extends AppCompatActivity implements HasAndroidIn
                     .commit();
         } else {
             searchViewExpanded = savedInstanceState.getBoolean(IS_SEARCH_VIEW_ICONIFIED);
+            searchViewContent = savedInstanceState.getString(QUERY_STRING);
         }
     }
 
@@ -48,6 +51,7 @@ public class MovieListActivity extends AppCompatActivity implements HasAndroidIn
         searchView = (SearchView) menuItem.getActionView();
         searchView.setImeOptions(EditorInfo.IME_FLAG_NO_EXTRACT_UI);
         searchView.setIconified(searchViewExpanded);
+        searchView.setQuery(searchViewContent, false);
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
             @Override
             public boolean onQueryTextSubmit(String query) {
@@ -69,6 +73,7 @@ public class MovieListActivity extends AppCompatActivity implements HasAndroidIn
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putBoolean(IS_SEARCH_VIEW_ICONIFIED, searchView.isIconified());
+        outState.putString(QUERY_STRING, searchView.getQuery().toString());
     }
 
     @Override


### PR DESCRIPTION
**Context:**
This PR fixes a bug whereby the searchview would lose state post-configuration changes

**Key changes:**
- contents of the `SearchView` are now persisted to the bundle so that we can retrieve and re-apply them post re-creation of the view after the configuration change (such as a rotation) has taken place.