### PR TITLE
Challenge 4 - refreshments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
         supportLibraryVersion = '1.6.1'
         recyclerView = '1.2.1'
         constraintLayout = '2.1.4'
+        swipeRefreshLayout = '1.1.0'
         retrofit = '2.9.0'
         lifecycle = '2.2.0'
         gson = '2.10.1'

--- a/features/list/build.gradle
+++ b/features/list/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$rootProject.supportLibraryVersion"
     implementation "androidx.recyclerview:recyclerview:$rootProject.recyclerView"
     implementation "androidx.constraintlayout:constraintlayout:$rootProject.constraintLayout"
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:$rootProject.swipeRefreshLayout"
     implementation "com.google.android.material:material:$rootProject.supportLibraryVersion"
 
     //api

--- a/features/list/src/main/java/com/vp/list/ListFragment.java
+++ b/features/list/src/main/java/com/vp/list/ListFragment.java
@@ -12,6 +12,7 @@ import com.google.android.material.bottomnavigation.BottomNavigationView;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -38,6 +39,7 @@ public class ListFragment extends Fragment implements GridPagingScrollListener.L
     private ListAdapter listAdapter;
     private ViewAnimator viewAnimator;
     private RecyclerView recyclerView;
+    private SwipeRefreshLayout swipeRefreshLayout;
     private ProgressBar progressBar;
     private TextView errorTextView;
     private String currentQuery = "Interview";
@@ -59,6 +61,7 @@ public class ListFragment extends Fragment implements GridPagingScrollListener.L
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         recyclerView = view.findViewById(R.id.recyclerView);
+        swipeRefreshLayout = view.findViewById(R.id.swipeRefreshLayout);
         viewAnimator = view.findViewById(R.id.viewAnimator);
         progressBar = view.findViewById(R.id.progressBar);
         errorTextView = view.findViewById(R.id.errorText);
@@ -103,6 +106,9 @@ public class ListFragment extends Fragment implements GridPagingScrollListener.L
         gridPagingScrollListener = new GridPagingScrollListener(layoutManager);
         gridPagingScrollListener.setLoadMoreItemsListener(this);
         recyclerView.addOnScrollListener(gridPagingScrollListener);
+
+        // Swipe down to Refresh
+        swipeRefreshLayout.setOnRefreshListener(() -> refreshSearch());
     }
 
     private void showProgressBar() {
@@ -110,7 +116,7 @@ public class ListFragment extends Fragment implements GridPagingScrollListener.L
     }
 
     private void showList() {
-        viewAnimator.setDisplayedChild(viewAnimator.indexOfChild(recyclerView));
+        viewAnimator.setDisplayedChild(viewAnimator.indexOfChild(swipeRefreshLayout));
     }
 
     private void showError() {
@@ -133,6 +139,7 @@ public class ListFragment extends Fragment implements GridPagingScrollListener.L
             }
         }
         gridPagingScrollListener.markLoading(false);
+        swipeRefreshLayout.setRefreshing(false);
     }
 
     private void setItemsData(@NonNull ListAdapter listAdapter, @NonNull SearchResult searchResult) {
@@ -160,6 +167,11 @@ public class ListFragment extends Fragment implements GridPagingScrollListener.L
         listAdapter.clearItems();
         listViewModel.searchMoviesByTitle(query, 1);
         showProgressBar();
+    }
+
+    public void refreshSearch() {
+        gridPagingScrollListener.markLoading(true);
+        listViewModel.refreshSearch();
     }
 
     @Override

--- a/features/list/src/main/java/com/vp/list/viewmodel/ListViewModel.java
+++ b/features/list/src/main/java/com/vp/list/viewmodel/ListViewModel.java
@@ -35,35 +35,22 @@ public class ListViewModel extends ViewModel {
     }
 
     public void searchMoviesByTitle(@NonNull String title, int page) {
-
         if (page == 1 && !title.equals(currentTitle)) {
             aggregatedItems.clear();
             currentTitle = title;
             liveData.setValue(SearchResult.inProgress());
         }
-        searchService.search(title, page).enqueue(new Callback<SearchResponse>() {
-            @Override
-            public void onResponse(@NonNull Call<SearchResponse> call, @NonNull Response<SearchResponse> response) {
 
-                SearchResponse result = response.body();
-
-                if (result != null) {
-                    aggregatedItems.addAll(result.getSearch());
-                    liveData.setValue(SearchResult.success(aggregatedItems, result.getTotalResults()));
-                }
-            }
-
-            @Override
-            public void onFailure(@NonNull Call<SearchResponse> call, @NonNull Throwable t) {
-                liveData.setValue(SearchResult.error());
-            }
-        });
+        initiateSearchAsync(page);
     }
 
     public void refreshSearch() {
         aggregatedItems.clear();
-        searchService.search(currentTitle, 1).enqueue(new Callback<SearchResponse>() {
+        initiateSearchAsync(1);
+    }
 
+    private void initiateSearchAsync(int page) {
+        searchService.search(currentTitle, page).enqueue(new Callback<SearchResponse>() {
             @Override
             public void onResponse(@NonNull Call<SearchResponse> call, @NonNull Response<SearchResponse> response) {
                 SearchResponse result = response.body();
@@ -78,6 +65,5 @@ public class ListViewModel extends ViewModel {
                 liveData.setValue(SearchResult.error());
             }
         });
-
     }
 }

--- a/features/list/src/main/java/com/vp/list/viewmodel/ListViewModel.java
+++ b/features/list/src/main/java/com/vp/list/viewmodel/ListViewModel.java
@@ -59,4 +59,25 @@ public class ListViewModel extends ViewModel {
             }
         });
     }
+
+    public void refreshSearch() {
+        aggregatedItems.clear();
+        searchService.search(currentTitle, 1).enqueue(new Callback<SearchResponse>() {
+
+            @Override
+            public void onResponse(@NonNull Call<SearchResponse> call, @NonNull Response<SearchResponse> response) {
+                SearchResponse result = response.body();
+                if (result != null) {
+                    aggregatedItems.addAll(result.getSearch());
+                    liveData.setValue(SearchResult.success(aggregatedItems, result.getTotalResults()));
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<SearchResponse> call, @NonNull Throwable t) {
+                liveData.setValue(SearchResult.error());
+            }
+        });
+
+    }
 }

--- a/features/list/src/main/res/layout/fragment_list.xml
+++ b/features/list/src/main/res/layout/fragment_list.xml
@@ -9,10 +9,16 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recyclerView"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/swipeRefreshLayout"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
         <ProgressBar
             android:id="@+id/progressBar"

--- a/features/list/src/test/java/com/vp/list/viewmodel/ListViewModelTest.java
+++ b/features/list/src/test/java/com/vp/list/viewmodel/ListViewModelTest.java
@@ -73,4 +73,22 @@ public class ListViewModelTest {
         assertThat(listViewModel.observeMovies().getValue().getListState()).isEqualTo(ListState.LOADED);
     }
 
+
+    @Test
+    public void shouldReturnSuccessStateForDataRefresh() {
+        //given
+        SearchResponse searchResponse = mock(SearchResponse.class);
+        when(searchResponse.getSearch()).thenReturn(Collections.emptyList());
+        when(searchResponse.getTotalResults()).thenReturn(0);
+        SearchService searchService = mock(SearchService.class);
+        when(searchService.search(anyString(), anyInt())).thenReturn(Calls.response(searchResponse));
+        ListViewModel listViewModel = new ListViewModel(searchService);
+
+        //when
+        listViewModel.refreshSearch();
+
+        //then
+        assertThat(listViewModel.observeMovies().getValue().getListState()).isEqualTo(ListState.LOADED);
+    }
+
 }


### PR DESCRIPTION
**Context:** 
This PR introduces a small new feature, whereby the user is able to refresh the search results for the current search query.

**Detail:**
A new method has been added to the viewmodel (and is being called by the view layer) to refresh the search results. This is done by clearing the state from the ViewModel, re-performing the search for the current search query for page 1. The view is then updated via the existing livedata mechanism. 

**Key changes:**
- utilises the SwipeToRefreshLayout widget to facilitate a typical android application behaviour to "swipe down to refresh" as can be enjoyed in popular android apps such as Gmail, Google Drive, Reddit, etc. 
- introduced new method `refreshSearch` method on the viewmodel to initiate the refresh of the search results for the current search query
- added a meaningful unit test to cover this new method exposed by the viewModel
