### PR TITLE
Bonus 3 loading indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You cracked all of those challenges, and you still can't get enough. We've got y
 
 1. Memory leaks - PR [Part 1](https://github.com/marctatham/veepee-android/pull/8) and [Part 2](https://github.com/marctatham/veepee-android/pull/9)
 2. Java to Kotlin conversion - PR https://github.com/marctatham/veepee-android/pull/10
-3. List loading indicator - this one I haven't had time to look into yet unfortunately
+3. List loading indicator - PR https://github.com/marctatham/veepee-android/pull/12
 
 # Feedback is always appreciated. 
 Even in the event another candidate is selected for this role, please take the time to provide your constructive criticism 

--- a/features/list/src/main/java/com/vp/list/ListFragment.kt
+++ b/features/list/src/main/java/com/vp/list/ListFragment.kt
@@ -112,7 +112,11 @@ class ListFragment : Fragment(), LoadMoreItemsListener, ListAdapter.OnItemClickL
     }
 
     private fun showProgressBar() {
-        viewAnimator.displayedChild = viewAnimator.indexOfChild(progressBar)
+        progressBar.visibility = View.VISIBLE
+    }
+
+    private fun hideProgressBar() {
+        progressBar.visibility = View.GONE
     }
 
     private fun showList() {
@@ -125,11 +129,15 @@ class ListFragment : Fragment(), LoadMoreItemsListener, ListAdapter.OnItemClickL
 
     private fun handleResult(listAdapter: ListAdapter, searchResult: SearchResult) {
         when (searchResult) {
-            SearchResult.Error -> showError()
+            SearchResult.Error -> {
+                showError()
+                hideProgressBar()
+            }
             SearchResult.InProgress -> showProgressBar()
             is SearchResult.Success -> {
                 setItemsData(listAdapter, searchResult)
                 showList()
+                hideProgressBar()
             }
         }
         gridPagingScrollListener.markLoading(false)

--- a/features/list/src/main/java/com/vp/list/viewmodel/ListViewModel.kt
+++ b/features/list/src/main/java/com/vp/list/viewmodel/ListViewModel.kt
@@ -25,9 +25,9 @@ class ListViewModel @Inject internal constructor(
         if (page == 1 && title != currentTitle) {
             aggregatedItems.clear()
             currentTitle = title
-            liveData.value = SearchResult.InProgress
         }
 
+        liveData.value = SearchResult.InProgress
         initiateSearchAsync(page)
     }
 

--- a/features/list/src/main/java/com/vp/list/viewmodel/ListViewModel.kt
+++ b/features/list/src/main/java/com/vp/list/viewmodel/ListViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.viewModelScope
 import com.vp.list.model.ListItem
 import com.vp.list.model.SearchResponse
 import com.vp.list.service.SearchService
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -40,8 +39,6 @@ class ListViewModel @Inject internal constructor(
         viewModelScope.launch {
             try {
                 val response: SearchResponse = searchService.search(currentTitle, page)
-                delay(3000)
-
                 aggregatedItems.addAll(response.search)
                 liveData.value = SearchResult.Success(aggregatedItems, response.totalResults)
             } catch (e: Exception) {

--- a/features/list/src/main/java/com/vp/list/viewmodel/ListViewModel.kt
+++ b/features/list/src/main/java/com/vp/list/viewmodel/ListViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.vp.list.model.ListItem
 import com.vp.list.model.SearchResponse
 import com.vp.list.service.SearchService
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -39,6 +40,8 @@ class ListViewModel @Inject internal constructor(
         viewModelScope.launch {
             try {
                 val response: SearchResponse = searchService.search(currentTitle, page)
+                delay(3000)
+
                 aggregatedItems.addAll(response.search)
                 liveData.value = SearchResult.Success(aggregatedItems, response.totalResults)
             } catch (e: Exception) {

--- a/features/list/src/main/res/layout/fragment_list.xml
+++ b/features/list/src/main/res/layout/fragment_list.xml
@@ -20,12 +20,6 @@
                 android:layout_height="match_parent" />
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-        <ProgressBar
-            android:id="@+id/progressBar"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center" />
-
         <TextView
             android:id="@+id/errorText"
             android:layout_width="wrap_content"
@@ -33,6 +27,12 @@
             android:layout_gravity="center"
             android:text="@string/data_loading_error" />
     </ViewAnimator>
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottomNavigation"


### PR DESCRIPTION
**Context:**
Fixes a view-layer bug whereby the progressBar would only be visible during the first page load, not when retrieving subsequent pages of data

**Detail:**
This has been done by:
- ensure we always update the mutableLiveData to have a state of `InProgress` when `searchMoviesByTitle` is called
- ProgressBar has been moved out of the VIewAnimator and into the parent FrameLayout container. 
This is because it makes no sense to rotate AWAY from the recyclerView while fetching a page of data, we want to display any existing data we already have but we want to display a progressBar ontop
- ListFragment observer implementation has been updated to show/hideProgressBar as appropriate
- ReadMe updated to include this PR 
